### PR TITLE
Add COC check for name and url properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = robot => {
             // If the comment is toxic, comment the comment
             if (toxicValue >= toxicityThreshold) {
               let comment
-              if (codeOfConduct) {
+              if (codeOfConduct && codeOfConduct.name && codeOfConduct.url) {
                 comment = config.sentimentBotReplyComment + 'Keep in mind, this repository uses the [' + codeOfConduct.name + '](' + codeOfConduct.url + ').'
               } else {
                 comment = config.sentimentBotReplyComment


### PR DESCRIPTION
Fixes issue #12 

@hiimbex I'm pretty much going off your guidance as per the issue for this. 

This should be ok - if the check for `codeOfConduct` is truthy only then will it check the `name` and/or `url` properties aswell so we won't get any "can't read x of undefined" errors or anything like that.

I did try looking at the Github issue you linked to but I'm guessing that's a private repo as I can't access it ;)