### PR TITLE
Use perspective-api-client and improve tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = robot => {
         if (repoData.data.code_of_conduct) {
           codeOfConduct = Object.assign({}, repoData.data.code_of_conduct)
         }
-        const response = await robot.perspective.analyze(body)
+        const response = await robot.perspective.analyze(body, {truncate: true})
         const toxicValue = response.attributeScores.TOXICITY.spanScores[0].score.value
         // If the comment is toxic, comment the comment
         if (toxicValue >= toxicityThreshold) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
-const googleapis = require('googleapis')
+const Perspective = require('perspective-api-client')
 
 module.exports = robot => {
+  robot.perspective = new Perspective(({apiKey: process.env.PERSPECTIVE_API_KEY}))
   robot.on('issue_comment', async context => {
     let codeOfConduct
     const config = await context.config('config.yml')
@@ -17,33 +18,18 @@ module.exports = robot => {
         if (repoData.data.code_of_conduct) {
           codeOfConduct = Object.assign({}, repoData.data.code_of_conduct)
         }
-        // Attempt to make perspective api requests template from google
-        const discoveryUrl = 'https://commentanalyzer.googleapis.com/$discovery/rest?version=v1alpha1'
-        googleapis.discoverAPI(discoveryUrl, (err, client) => {
-          if (err) {
-            throw err
+        const response = await robot.perspective.analyze(body)
+        const toxicValue = response.attributeScores.TOXICITY.spanScores[0].score.value
+        // If the comment is toxic, comment the comment
+        if (toxicValue >= toxicityThreshold) {
+          let comment
+          if (codeOfConduct && codeOfConduct.name && codeOfConduct.url) {
+            comment = config.sentimentBotReplyComment + 'Keep in mind, this repository uses the [' + codeOfConduct.name + '](' + codeOfConduct.url + ').'
+          } else {
+            comment = config.sentimentBotReplyComment
           }
-          const analyzeRequest = {
-            comment: {text: body},
-            requestedAttributes: {TOXICITY: {}}
-          }
-          client.comments.analyze({key: process.env.PERSPECTIVE_API_KEY, resource: analyzeRequest}, (err, response) => {
-            if (err) {
-              throw err
-            }
-            const toxicValue = response.attributeScores.TOXICITY.spanScores[0].score.value
-            // If the comment is toxic, comment the comment
-            if (toxicValue >= toxicityThreshold) {
-              let comment
-              if (codeOfConduct && codeOfConduct.name && codeOfConduct.url) {
-                comment = config.sentimentBotReplyComment + 'Keep in mind, this repository uses the [' + codeOfConduct.name + '](' + codeOfConduct.url + ').'
-              } else {
-                comment = config.sentimentBotReplyComment
-              }
-              context.github.issues.createComment(context.issue({body: comment}))
-            }
-          })
-        })
+          context.github.issues.createComment(context.issue({body: comment}))
+        }
       }
     }
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -2486,13 +2486,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2500,6 +2493,13 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -2686,48 +2686,12 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
-    "google-auth-library": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-      "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-      "requires": {
-        "gtoken": "1.2.2",
-        "jws": "3.1.4",
-        "lodash.noop": "3.0.1",
-        "request": "2.81.0"
-      }
-    },
     "google-p12-pem": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
       "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
       "requires": {
         "node-forge": "0.7.1"
-      }
-    },
-    "googleapis": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-19.0.0.tgz",
-      "integrity": "sha1-hwDrFClHd+DBlhUgUf1jZwYd3oU=",
-      "requires": {
-        "async": "2.3.0",
-        "google-auth-library": "0.10.0",
-        "string-template": "1.0.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.3.0.tgz",
-          "integrity": "sha1-EBPRBRBH3TIP4k5JTVxm7K9hR9k=",
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        }
       }
     },
     "graceful-fs": {
@@ -2751,17 +2715,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
-    },
-    "gtoken": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.2.tgz",
-      "integrity": "sha1-Fyd2oanZasCfwioA9b6DzubeiCA=",
-      "requires": {
-        "google-p12-pem": "0.1.2",
-        "jws": "3.1.4",
-        "mime": "1.3.6",
-        "request": "2.81.0"
-      }
     },
     "handlebars": {
       "version": "4.0.11",
@@ -4466,6 +4419,11 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -4477,10 +4435,10 @@
         "lodash.isarray": "3.0.4"
       }
     },
-    "lodash.noop": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
-      "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw="
+    "lodash.merge": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -5008,6 +4966,69 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+    },
+    "perspective-api-client": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perspective-api-client/-/perspective-api-client-1.0.0.tgz",
+      "integrity": "sha512-jOMQWp57OntVC7B/WsT8YTCAGptqBZHxUEjxr+BrJvykjsABmOv+ZyJyVDKqou4ks67uw+Cj0hNPJPGamDHdgA==",
+      "requires": {
+        "googleapis": "23.0.0",
+        "lodash.merge": "4.6.0",
+        "striptags": "3.1.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "google-auth-library": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.12.0.tgz",
+          "integrity": "sha512-79qCXtJ1VweBmmLr4yLq9S4clZB2p5Y+iACvuKk9gu4JitEnPc+bQFmYvtCYehVR44MQzD1J8DVmYW2w677IEw==",
+          "requires": {
+            "gtoken": "1.2.3",
+            "jws": "3.1.4",
+            "lodash.isstring": "4.0.1",
+            "lodash.merge": "4.6.0",
+            "request": "2.81.0"
+          }
+        },
+        "googleapis": {
+          "version": "23.0.0",
+          "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-23.0.0.tgz",
+          "integrity": "sha512-obSOIKygIU/CEenIf4I5IcfEfCxaGp3dsvuxVfrmoTyQvrW3NK+CU+HmaSiQ8tJ+xf0R6jxHWi7eWkp7ReW8wA==",
+          "requires": {
+            "async": "2.6.0",
+            "google-auth-library": "0.12.0",
+            "string-template": "1.0.0"
+          }
+        },
+        "gtoken": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.3.tgz",
+          "integrity": "sha512-wQAJflfoqSgMWrSBk9Fg86q+sd6s7y6uJhIvvIPz++RElGlMtEqsdAR2oWwZ/WTEtp7P9xFbJRrT976oRgzJ/w==",
+          "requires": {
+            "google-p12-pem": "0.1.2",
+            "jws": "3.1.4",
+            "mime": "1.6.0",
+            "request": "2.81.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+        }
+      }
     },
     "pify": {
       "version": "2.3.0",
@@ -5853,11 +5874,6 @@
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -5897,6 +5913,11 @@
         "strip-ansi": "3.0.1"
       }
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -5925,6 +5946,11 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "striptags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
     },
     "supports-color": {
       "version": "3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2686,12 +2686,49 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
+    "google-auth-library": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.12.0.tgz",
+      "integrity": "sha512-79qCXtJ1VweBmmLr4yLq9S4clZB2p5Y+iACvuKk9gu4JitEnPc+bQFmYvtCYehVR44MQzD1J8DVmYW2w677IEw==",
+      "requires": {
+        "gtoken": "1.2.3",
+        "jws": "3.1.4",
+        "lodash.isstring": "4.0.1",
+        "lodash.merge": "4.6.0",
+        "request": "2.81.0"
+      }
+    },
     "google-p12-pem": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
       "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
       "requires": {
         "node-forge": "0.7.1"
+      }
+    },
+    "googleapis": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-23.0.0.tgz",
+      "integrity": "sha512-obSOIKygIU/CEenIf4I5IcfEfCxaGp3dsvuxVfrmoTyQvrW3NK+CU+HmaSiQ8tJ+xf0R6jxHWi7eWkp7ReW8wA==",
+      "requires": {
+        "async": "2.6.0",
+        "google-auth-library": "0.12.0",
+        "string-template": "1.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
       }
     },
     "graceful-fs": {
@@ -2715,6 +2752,24 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+    },
+    "gtoken": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.3.tgz",
+      "integrity": "sha512-wQAJflfoqSgMWrSBk9Fg86q+sd6s7y6uJhIvvIPz++RElGlMtEqsdAR2oWwZ/WTEtp7P9xFbJRrT976oRgzJ/w==",
+      "requires": {
+        "google-p12-pem": "0.1.2",
+        "jws": "3.1.4",
+        "mime": "1.6.0",
+        "request": "2.81.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+        }
+      }
     },
     "handlebars": {
       "version": "4.0.11",
@@ -4968,66 +5023,13 @@
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
     },
     "perspective-api-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/perspective-api-client/-/perspective-api-client-1.0.0.tgz",
-      "integrity": "sha512-jOMQWp57OntVC7B/WsT8YTCAGptqBZHxUEjxr+BrJvykjsABmOv+ZyJyVDKqou4ks67uw+Cj0hNPJPGamDHdgA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/perspective-api-client/-/perspective-api-client-1.1.0.tgz",
+      "integrity": "sha512-LHZLI5nzucILFqB4typXZbPNM2lUhYB2skOkqzH5tHJm6mr4SBlSLDU4277gudmWut3coey46NMajNQ5d4DxIQ==",
       "requires": {
         "googleapis": "23.0.0",
         "lodash.merge": "4.6.0",
         "striptags": "3.1.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "google-auth-library": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.12.0.tgz",
-          "integrity": "sha512-79qCXtJ1VweBmmLr4yLq9S4clZB2p5Y+iACvuKk9gu4JitEnPc+bQFmYvtCYehVR44MQzD1J8DVmYW2w677IEw==",
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.isstring": "4.0.1",
-            "lodash.merge": "4.6.0",
-            "request": "2.81.0"
-          }
-        },
-        "googleapis": {
-          "version": "23.0.0",
-          "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-23.0.0.tgz",
-          "integrity": "sha512-obSOIKygIU/CEenIf4I5IcfEfCxaGp3dsvuxVfrmoTyQvrW3NK+CU+HmaSiQ8tJ+xf0R6jxHWi7eWkp7ReW8wA==",
-          "requires": {
-            "async": "2.6.0",
-            "google-auth-library": "0.12.0",
-            "string-template": "1.0.0"
-          }
-        },
-        "gtoken": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.3.tgz",
-          "integrity": "sha512-wQAJflfoqSgMWrSBk9Fg86q+sd6s7y6uJhIvvIPz++RElGlMtEqsdAR2oWwZ/WTEtp7P9xFbJRrT976oRgzJ/w==",
-          "requires": {
-            "google-p12-pem": "0.1.2",
-            "jws": "3.1.4",
-            "mime": "1.6.0",
-            "request": "2.81.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        },
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-        }
       }
     },
     "pify": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "homepage": "https://github.com/behaviorbot/sentiment-bot#readme",
   "dependencies": {
-    "googleapis": "^19.0.0",
     "js-yaml": "^3.9.0",
+    "perspective-api-client": "^1.0.0",
     "probot": "^3.0.0",
     "request": "^2.81.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/behaviorbot/sentiment-bot#readme",
   "dependencies": {
     "js-yaml": "^3.9.0",
-    "perspective-api-client": "^1.0.0",
+    "perspective-api-client": "^1.1.0",
     "probot": "^3.0.0",
     "request": "^2.81.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -3,41 +3,74 @@ const {createRobot} = require('probot')
 const plugin = require('..')
 const payload = require('./events/payload')
 
-describe('sentiment-bot', () => {
-  let robot
-  let github
+const createTestRobot = ({toxicity}) => {
+  // PERSPECTIVE_API_KEY must be set
+  process.env.PERSPECTIVE_API_KEY = 'mock-key'
+  const robot = createRobot()
+  plugin(robot)
 
-  beforeEach(() => {
-    robot = createRobot()
-    plugin(robot)
-
-    github = {
-      repos: {
-        getContent: expect.createSpy().andReturn(Promise.resolve({
-          data: {
-            content: Buffer.from(`
-              sentimentBotToxicityThreshold: 0.3
-              sentimentBotReplyComment: "That comment was toxic"`).toString('base64')
-          }
-        })),
-        get: expect.createSpy().andReturn(Promise.resolve({
-          data: {
-            code_of_conduct: Buffer.from(`
-              name: 'Contributor Covenenant'
-              url: https://github.com/hiimbex/testing-things/blob/master/CODE_OF_CONDUCT.md`).toString('base64')
-          }
-        }))
-      },
-      issues: {
-        createComment: expect.createSpy()
-      }
+  const github = {
+    repos: {
+      getContent: expect.createSpy().andReturn(Promise.resolve({
+        data: {
+          content: Buffer.from(`
+            sentimentBotToxicityThreshold: 0.3
+            sentimentBotReplyComment: "That comment was toxic"`).toString('base64')
+        }
+      })),
+      get: expect.createSpy().andReturn(Promise.resolve({
+        data: {
+          code_of_conduct: Buffer.from(`
+            name: 'Contributor Covenenant'
+            url: https://github.com/hiimbex/testing-things/blob/master/CODE_OF_CONDUCT.md`).toString('base64')
+        }
+      }))
+    },
+    issues: {
+      createComment: expect.createSpy()
     }
+  }
 
-    robot.auth = () => Promise.resolve(github)
-  })
+  // Mock perspective API client
+  const perspective = {
+    analyze: expect.createSpy().andReturn(Promise.resolve(
+      {
+        attributeScores: {
+          TOXICITY: {
+            spanScores: [
+              {
+                begin: 0,
+                end: 56,
+                score: {
+                  value: toxicity,
+                  type: 'PROBABILITY'
+                }
+              }
+            ],
+            summaryScore: {
+              value: toxicity,
+              type: 'PROBABILITY'
+            }
+          }
+        },
+        languages: [
+          'en'
+        ]
+      }
+    ))
+  }
 
+  robot.auth = () => Promise.resolve(github)
+  robot.perspective = perspective
+  return robot
+}
+
+describe('sentiment-bot', () => {
   describe('sentiment-bot success', () => {
     it('posts a comment because the user was toxic', async () => {
+      const robot = createTestRobot({toxicity: 0.8})
+      const github = await robot.auth()
+      const perspective = robot.perspective
       await robot.receive(payload)
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'hiimbex',
@@ -52,13 +85,16 @@ describe('sentiment-bot', () => {
           Accept: 'application/vnd.github.scarlet-witch-preview+json'
         }
       })
-      // Imitate google api stuff
-      // expect(github.issues.createComment).toHaveBeenCalled();
+      expect(perspective.analyze).toHaveBeenCalled()
+      expect(github.issues.createComment).toHaveBeenCalled()
     })
   })
 
   describe('sentiment-bot fail', () => {
     it('does not post a comment because the user was not toxic', async () => {
+      const robot = createTestRobot({toxicity: 0.2})
+      const github = await robot.auth()
+      const perspective = robot.perspective
       await robot.receive(payload)
 
       expect(github.repos.getContent).toHaveBeenCalledWith({
@@ -73,6 +109,7 @@ describe('sentiment-bot', () => {
           Accept: 'application/vnd.github.scarlet-witch-preview+json'
         }
       })
+      expect(perspective.analyze).toHaveBeenCalled()
       expect(github.issues.createComment).toNotHaveBeenCalled()
     })
   })


### PR DESCRIPTION
- Use a client library, [perspective-api-client](https://github.com/sloria/perspective-api-client), to simplify the codebase
- This makes it simpler to mock Perspective API responses. The tests now test that GitHub comments are or are not made based on the toxicity score returned by Perspective.
- Prevent an error when sending comments with > 3000 characters