### PR TITLE
Upgrade perspective-api-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -246,6 +246,33 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "axios": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "requires": {
+        "follow-redirects": "1.2.6",
+        "is-buffer": "1.1.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz",
+          "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
+          "requires": {
+            "debug": "3.1.0"
+          }
+        }
+      }
+    },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
@@ -2686,51 +2713,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
-    "google-auth-library": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.12.0.tgz",
-      "integrity": "sha512-79qCXtJ1VweBmmLr4yLq9S4clZB2p5Y+iACvuKk9gu4JitEnPc+bQFmYvtCYehVR44MQzD1J8DVmYW2w677IEw==",
-      "requires": {
-        "gtoken": "1.2.3",
-        "jws": "3.1.4",
-        "lodash.isstring": "4.0.1",
-        "lodash.merge": "4.6.0",
-        "request": "2.81.0"
-      }
-    },
-    "google-p12-pem": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
-      "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
-      "requires": {
-        "node-forge": "0.7.1"
-      }
-    },
-    "googleapis": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-23.0.0.tgz",
-      "integrity": "sha512-obSOIKygIU/CEenIf4I5IcfEfCxaGp3dsvuxVfrmoTyQvrW3NK+CU+HmaSiQ8tJ+xf0R6jxHWi7eWkp7ReW8wA==",
-      "requires": {
-        "async": "2.6.0",
-        "google-auth-library": "0.12.0",
-        "string-template": "1.0.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        }
-      }
-    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -2752,24 +2734,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
-    },
-    "gtoken": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.3.tgz",
-      "integrity": "sha512-wQAJflfoqSgMWrSBk9Fg86q+sd6s7y6uJhIvvIPz++RElGlMtEqsdAR2oWwZ/WTEtp7P9xFbJRrT976oRgzJ/w==",
-      "requires": {
-        "google-p12-pem": "0.1.2",
-        "jws": "3.1.4",
-        "mime": "1.6.0",
-        "request": "2.81.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-        }
-      }
     },
     "handlebars": {
       "version": "4.0.11",
@@ -4474,11 +4438,6 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -4730,11 +4689,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
       "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ="
-    },
-    "node-forge": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
-      "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -5023,11 +4977,11 @@
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
     },
     "perspective-api-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/perspective-api-client/-/perspective-api-client-1.1.0.tgz",
-      "integrity": "sha512-LHZLI5nzucILFqB4typXZbPNM2lUhYB2skOkqzH5tHJm6mr4SBlSLDU4277gudmWut3coey46NMajNQ5d4DxIQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/perspective-api-client/-/perspective-api-client-2.0.0.tgz",
+      "integrity": "sha512-+9ABurVpysjIHtDo3nZM2+ErV2nD7xxlri8G2gmA8A9R/pigXAz7OLsDHDUDPStOJx64M73FY7SAUmarKJbGJg==",
       "requires": {
-        "googleapis": "23.0.0",
+        "axios": "0.17.1",
         "lodash.merge": "4.6.0",
         "striptags": "3.1.1"
       }
@@ -5899,11 +5853,6 @@
           }
         }
       }
-    },
-    "string-template": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
-      "integrity": "sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y="
     },
     "string-width": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/behaviorbot/sentiment-bot#readme",
   "dependencies": {
     "js-yaml": "^3.9.0",
-    "perspective-api-client": "^1.1.0",
+    "perspective-api-client": "^2.0.0",
     "probot": "^3.0.0",
     "request": "^2.81.0"
   },


### PR DESCRIPTION
The new version uses the comment analyzer endpoint directly
rather than relying on the discovery endpoint, so this
saves 1 API request per comment