### PR TITLE
Update sentiment-bot to require Probot v7.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 const Perspective = require('perspective-api-client')
 
-module.exports = robot => {
-  robot.perspective = new Perspective(({apiKey: process.env.PERSPECTIVE_API_KEY}))
-  robot.on('issue_comment', async context => {
+module.exports = app => {
+  app.perspective = new Perspective(({apiKey: process.env.PERSPECTIVE_API_KEY}))
+  app.on('issue_comment', async context => {
     let codeOfConduct
     const config = await context.config('config.yml')
     if (config && !context.isBot) {
@@ -18,7 +18,7 @@ module.exports = robot => {
         if (repoData.data.code_of_conduct) {
           codeOfConduct = Object.assign({}, repoData.data.code_of_conduct)
         }
-        const response = await robot.perspective.analyze(body, {truncate: true})
+        const response = await app.perspective.analyze(body, {truncate: true})
         const toxicValue = response.attributeScores.TOXICITY.summaryScore.value
         // If the comment is toxic, comment the comment
         if (toxicValue >= toxicityThreshold) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,72 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@octokit/rest": {
-      "version": "15.9.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.9.1.tgz",
-      "integrity": "sha512-5BjHgqiyRzwfkeStF+kSQa7qYS+2KAjf7jzC9XNuGeEzAZVFn6qj9wC8cIjbegqLMxpq8SjHHw305gynep5+Ug==",
-      "requires": {
-        "before-after-hook": "1.1.0",
-        "btoa-lite": "1.0.0",
-        "debug": "3.1.0",
-        "http-proxy-agent": "2.1.0",
-        "https-proxy-agent": "2.2.1",
-        "lodash": "4.17.10",
-        "node-fetch": "2.1.2",
-        "url-template": "2.0.8"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-          "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
-          "requires": {
-            "es6-promisify": "5.0.0"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-          "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-          "requires": {
-            "agent-base": "4.2.0",
-            "debug": "3.1.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-        }
-      }
-    },
-    "@octokit/webhooks": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-3.1.1.tgz",
-      "integrity": "sha512-VqpGDClqhLw5sKV+or5AnkPmUyur/Oktr9paqiR+yH69Tew9QA/vXHjKP4zctxj5PVAsOdTQFhSzP53qbNLVOg==",
-      "requires": {
-        "buffer-equal-constant-time": "1.0.1",
-        "debug": "3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -115,6 +49,14 @@
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
+      }
+    },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
@@ -360,6 +302,11 @@
       "requires": {
         "hoek": "2.16.3"
       }
+    },
+    "bottleneck": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.11.2.tgz",
+      "integrity": "sha512-rC2HVbtSaTgFsrnW3nkODmSHSGewyGVGeIN1HlOsFhgiRu0hrJqQu1m1icRYlc1L7Jg4Sz62bj/2EynY5HcqMA=="
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -830,6 +777,11 @@
         "esutils": "2.0.2",
         "isarray": "1.0.0"
       }
+    },
+    "dotenv": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
+      "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg=="
     },
     "dtrace-provider": {
       "version": "0.8.5",
@@ -1360,11 +1312,6 @@
         }
       }
     },
-    "express-async-errors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-2.1.2.tgz",
-      "integrity": "sha512-irtoGiU0TGf8XNpPPndzGaOkcxX0Hue3jGoEBJCCk88uKNOp2y43Gvc7hTzf+0nilBK1ucLYdIIyWSscHHWTGA=="
-    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -1713,6 +1660,30 @@
         "sshpk": "1.13.1"
       }
     },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "4.2.1",
+        "debug": "3.2.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "ignore": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
@@ -1790,6 +1761,11 @@
       "requires": {
         "is-callable": "1.1.3"
       }
+    },
+    "is-base64": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-0.0.5.tgz",
+      "integrity": "sha512-eRLie1GvKWp5Hab3x0uZXOvxrlw72elV2qEcvrNeoqNv6W30BjyvdiEqouaIrU3qh5KWRlxJp7iDLipA/hNOsA=="
     },
     "is-boolean-object": {
       "version": "1.0.0",
@@ -2015,6 +1991,29 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
+      "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
+      "requires": {
+        "jws": "3.1.5",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.once": "4.1.1",
+        "ms": "2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
@@ -2047,6 +2046,15 @@
         "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.9",
+        "safe-buffer": "5.1.0"
+      }
+    },
+    "jws": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "requires": {
+        "jwa": "1.1.5",
         "safe-buffer": "5.1.0"
       }
     },
@@ -2241,6 +2249,11 @@
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
       }
+    },
+    "macos-release": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+      "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
     },
     "md5": {
       "version": "2.2.1",
@@ -2556,6 +2569,15 @@
         "lcid": "1.0.0"
       }
     },
+    "os-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+      "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+      "requires": {
+        "macos-release": "1.1.0",
+        "win-release": "1.1.1"
+      }
+    },
     "p-limit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
@@ -2723,148 +2745,87 @@
       "dev": true
     },
     "probot": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/probot/-/probot-6.2.0.tgz",
-      "integrity": "sha512-oYdStiyYaNSXIUkmBDKkGsnEgD/TUKb1B1wM9/6w/WJaZ7w3jzy6U6GYOH0PcwNijdzL3rhgmpHIcNK6C2+7hw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/probot/-/probot-7.2.0.tgz",
+      "integrity": "sha512-bVNJ174eWOUvPSrAOCflzvbS4XgfS9t32I2uGy256IwMl7Q6SZt/MZ8hg3FrK/bHb9q40F74MB7ODZ1mimhKjA==",
       "requires": {
-        "@octokit/rest": "15.9.1",
-        "@octokit/webhooks": "3.1.1",
-        "bottleneck": "2.5.0",
+        "@octokit/rest": "15.13.0",
+        "@octokit/webhooks": "5.0.2",
+        "bottleneck": "2.11.2",
         "bunyan": "1.8.12",
         "bunyan-format": "0.2.1",
         "bunyan-sentry-stream": "1.1.0",
         "cache-manager": "2.4.0",
-        "commander": "2.15.1",
-        "dotenv": "5.0.1",
+        "commander": "2.18.0",
+        "dotenv": "6.0.0",
         "express": "4.16.3",
-        "express-async-errors": "2.1.2",
+        "express-async-errors": "3.0.0",
         "hbs": "4.0.1",
+        "is-base64": "0.0.5",
         "js-yaml": "3.12.0",
         "jsonwebtoken": "8.3.0",
         "pkg-conf": "2.0.0",
         "promise-events": "0.1.3",
+        "qs": "6.5.2",
         "raven": "2.6.3",
         "resolve": "1.8.1",
-        "semver": "5.5.0"
+        "semver": "5.5.1",
+        "update-dotenv": "1.1.0",
+        "uuid": "3.3.2"
       },
       "dependencies": {
-        "accepts": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-          "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+        "@octokit/rest": {
+          "version": "15.13.0",
+          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.13.0.tgz",
+          "integrity": "sha512-zgsrqMCLcv4XqpT0QGUykHTvKo33aCVzXP86Bq6HmeKuwY6hEWJ+AVCeL/m3bXk1JBpLyBgzjJDfWEfZcqsR6g==",
           "requires": {
-            "mime-types": "2.1.18",
-            "negotiator": "0.6.1"
+            "before-after-hook": "1.1.0",
+            "btoa-lite": "1.0.0",
+            "debug": "3.2.5",
+            "http-proxy-agent": "2.1.0",
+            "https-proxy-agent": "2.2.1",
+            "lodash": "4.17.11",
+            "node-fetch": "2.1.2",
+            "universal-user-agent": "2.0.1",
+            "url-template": "2.0.8"
           }
         },
-        "bottleneck": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.5.0.tgz",
-          "integrity": "sha512-j19zrMCIe0LmTfCjIDNk4V40z0Plc8ZfjBsfWGOdJhJAAKXqwCOoY2k85N5rUmFerrT9lr6oQWiIIb771je03g=="
+        "@octokit/webhooks": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-5.0.2.tgz",
+          "integrity": "sha512-htxI5cNiaEOlJbero6akw8bVZm3maN7LtCZbczxJQko3NvQqiROmzryE39+FnaoaHkQr6IAOx2JnPBZlkPHnVQ==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "debug": "4.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.0.1.tgz",
+              "integrity": "sha512-K23FHJ/Mt404FSlp6gSZCevIbTMLX0j3fmHhUEhQ3Wq0FMODW3+cUSoLdy1Gx4polAf4t/lphhmHH35BB8cLYw==",
+              "requires": {
+                "ms": "2.1.1"
+              }
+            }
+          }
         },
         "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-        },
-        "content-type": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+          "version": "2.18.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
+          "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ=="
         },
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.1"
           }
         },
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-        },
-        "dotenv": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
-        },
-        "encodeurl": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-          "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-        },
-        "etag": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-        },
-        "express": {
-          "version": "4.16.3",
-          "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
-          "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
-          "requires": {
-            "accepts": "1.3.5",
-            "array-flatten": "1.1.1",
-            "body-parser": "1.18.2",
-            "content-disposition": "0.5.2",
-            "content-type": "1.0.4",
-            "cookie": "0.3.1",
-            "cookie-signature": "1.0.6",
-            "debug": "2.6.9",
-            "depd": "1.1.2",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
-            "finalhandler": "1.1.1",
-            "fresh": "0.5.2",
-            "merge-descriptors": "1.0.1",
-            "methods": "1.1.2",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "path-to-regexp": "0.1.7",
-            "proxy-addr": "2.0.3",
-            "qs": "6.5.1",
-            "range-parser": "1.2.0",
-            "safe-buffer": "5.1.1",
-            "send": "0.16.2",
-            "serve-static": "1.13.2",
-            "setprototypeof": "1.1.0",
-            "statuses": "1.4.0",
-            "type-is": "1.6.16",
-            "utils-merge": "1.0.1",
-            "vary": "1.1.2"
-          }
-        },
-        "finalhandler": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-          "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-          "requires": {
-            "debug": "2.6.9",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.4.0",
-            "unpipe": "1.0.0"
-          }
-        },
-        "forwarded": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
-        },
-        "fresh": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-        },
-        "ipaddr.js": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
-          "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+        "express-async-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.0.0.tgz",
+          "integrity": "sha512-voLFcOahCxhY8v1EIrM2snaOMHWcB+F2SJWTWPmc2VmK5z/TmU++01ANae4BAjBT+Dbr9k929OV1EFkuSOsACA=="
         },
         "js-yaml": {
           "version": "3.12.0",
@@ -2875,74 +2836,20 @@
             "esprima": "4.0.0"
           }
         },
-        "jsonwebtoken": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
-          "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
-          "requires": {
-            "jws": "3.1.5",
-            "lodash.includes": "4.3.0",
-            "lodash.isboolean": "3.0.3",
-            "lodash.isinteger": "4.0.4",
-            "lodash.isnumber": "3.0.3",
-            "lodash.isplainobject": "4.0.6",
-            "lodash.isstring": "4.0.1",
-            "lodash.once": "4.1.1",
-            "ms": "2.1.1"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-            }
-          }
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         },
-        "jws": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
-          "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
-          "requires": {
-            "jwa": "1.1.5",
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "mime": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
-        },
-        "mime-db": {
-          "version": "1.33.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
-        },
-        "mime-types": {
-          "version": "2.1.18",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-          "requires": {
-            "mime-db": "1.33.0"
-          }
-        },
-        "parseurl": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-          "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
-        },
-        "proxy-addr": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
-          "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
-          "requires": {
-            "forwarded": "0.1.2",
-            "ipaddr.js": "1.6.0"
-          }
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "resolve": {
           "version": "1.8.1",
@@ -2952,75 +2859,15 @@
             "path-parse": "1.0.5"
           }
         },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
         "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
         },
-        "send": {
-          "version": "0.16.2",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-          "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-          "requires": {
-            "debug": "2.6.9",
-            "depd": "1.1.2",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
-            "fresh": "0.5.2",
-            "http-errors": "1.6.2",
-            "mime": "1.4.1",
-            "ms": "2.0.0",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.4.0"
-          }
-        },
-        "serve-static": {
-          "version": "1.13.2",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-          "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-          "requires": {
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "parseurl": "1.3.2",
-            "send": "0.16.2"
-          }
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-        },
-        "type-is": {
-          "version": "1.6.16",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-          "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-          "requires": {
-            "media-typer": "0.3.0",
-            "mime-types": "2.1.18"
-          }
-        },
-        "utils-merge": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-        },
-        "vary": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -3271,8 +3118,7 @@
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-      "dev": true
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
     "send": {
       "version": "0.16.2",
@@ -3768,10 +3614,23 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
+    "universal-user-agent": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.1.tgz",
+      "integrity": "sha512-vz+heWVydO0iyYAa65VHD7WZkYzhl7BeNVy4i54p4TF8OMiLSXdbuQe4hm+fmWAsL+rVibaQHXfhvkw3c1Ws2w==",
+      "requires": {
+        "os-name": "2.0.1"
+      }
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "update-dotenv": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-dotenv/-/update-dotenv-1.1.0.tgz",
+      "integrity": "sha512-37KqjTZTJoXGQI6iI6PNo9lRsBHNtisBISyDCYLrR0hf2YlQo0Gw18v6DXseWk7kWJr33sHh5sMP78ofzbd/ag=="
     },
     "url-template": {
       "version": "2.0.8",
@@ -3832,6 +3691,14 @@
       "integrity": "sha1-MbTbZnjyrgHDnqn7hyWpAx5Vins=",
       "requires": {
         "foreachasync": "3.0.0"
+      }
+    },
+    "win-release": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+      "requires": {
+        "semver": "5.3.0"
       }
     },
     "window-size": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.16.3",
     "js-yaml": "^3.9.0",
     "perspective-api-client": "^2.0.0",
-    "probot": "^6.2.0",
+    "probot": "^7.2.0",
     "request": "^2.81.0"
   },
   "devDependencies": {

--- a/test/events/payload.json
+++ b/test/events/payload.json
@@ -1,5 +1,5 @@
 {
-    "event": "issue_comment",
+    "name": "issue_comment",
     "payload": {
         "action": "created",
         "issue": {

--- a/test/index.js
+++ b/test/index.js
@@ -3,11 +3,11 @@ const {Application} = require('probot')
 const plugin = require('..')
 const payload = require('./events/payload')
 
-const createTestRobot = ({toxicity}) => {
+const createTestApp = ({toxicity}) => {
   // PERSPECTIVE_API_KEY must be set
   process.env.PERSPECTIVE_API_KEY = 'mock-key'
-  const robot = new Application()
-  plugin(robot)
+  const app = new Application()
+  plugin(app)
 
   const github = {
     repos: {
@@ -60,18 +60,18 @@ const createTestRobot = ({toxicity}) => {
     ))
   }
 
-  robot.auth = () => Promise.resolve(github)
-  robot.perspective = perspective
-  return robot
+  app.auth = () => Promise.resolve(github)
+  app.perspective = perspective
+  return app
 }
 
 describe('sentiment-bot', () => {
   describe('sentiment-bot success', () => {
     it('posts a comment because the user was toxic', async () => {
-      const robot = createTestRobot({toxicity: 0.8})
-      const github = await robot.auth()
-      const perspective = robot.perspective
-      await robot.receive(payload)
+      const app = createTestApp({toxicity: 0.8})
+      const github = await app.auth()
+      const perspective = app.perspective
+      await app.receive(payload)
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'hiimbex',
         repo: 'testing-things',
@@ -92,10 +92,10 @@ describe('sentiment-bot', () => {
 
   describe('sentiment-bot fail', () => {
     it('does not post a comment because the user was not toxic', async () => {
-      const robot = createTestRobot({toxicity: 0.2})
-      const github = await robot.auth()
-      const perspective = robot.perspective
-      await robot.receive(payload)
+      const app = createTestApp({toxicity: 0.2})
+      const github = await app.auth()
+      const perspective = app.perspective
+      await app.receive(payload)
 
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'hiimbex',

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,12 @@
 const expect = require('expect')
-const {createRobot} = require('probot')
+const {Application} = require('probot')
 const plugin = require('..')
 const payload = require('./events/payload')
 
 const createTestRobot = ({toxicity}) => {
   // PERSPECTIVE_API_KEY must be set
   process.env.PERSPECTIVE_API_KEY = 'mock-key'
-  const robot = createRobot()
+  const robot = new Application()
   plugin(robot)
 
   const github = {


### PR DESCRIPTION
In the spirit of participating for Hacktoberfest, I'm making a PR to help out with this [Updating Probot](https://github.com/behaviorbot/welcome/issues/15) issue in [welcome](https://github.com/behaviorbot/welcome) opened by @hiimbex. 

This PR will
- update the `package.json` to require Probot v7.2.0 or higher
- update tests and mock payload to reflect changes in the new major version of Probot

This is my first time contributing to this project! Please let me know if I'm missing anything :)